### PR TITLE
It is github.com, not dot org ;)

### DIFF
--- a/lib/lolcat/cat.rb
+++ b/lib/lolcat/cat.rb
@@ -75,8 +75,8 @@ Examples:
   lolcat            Copy standard input to standard output.
   fortune | lolcat  Display a rainbow cookie.
 
-Report lolcat bugs to <http://www.github.org/busyloop/lolcat/issues>
-lolcat home page: <http://www.github.org/busyloop/lolcat/>
+Report lolcat bugs to <https://github.com/busyloop/lolcat/issues>
+lolcat home page: <https://github.com/busyloop/lolcat/>
 Report lolcat translation bugs to <http://speaklolcat.com/>
 
 FOOTER


### PR DESCRIPTION
Hey,

You have mispelled the github site name in the help text; it's `https://github.com` not `http://www.github.org`! ;)

Cheers,
Vittorio G
