### PR TITLE
24-bit truecolor support =＾● ⋏ ●＾=

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,2 +1,4 @@
 source "http://rubygems.org"
 gemspec
+
+gem 'paint', git: 'https://github.com/vaz/paint', branch: 'truecolor'

--- a/lib/lolcat/cat.rb
+++ b/lib/lolcat/cat.rb
@@ -48,6 +48,8 @@ HEADER
       opt :animate, "Enable psychedelics", :short => 'a', :default => false
       opt :duration, "Animation duration", :short => 'd', :default => 12
       opt :speed, "Animation speed", :short => 's', :default => 20.0
+      opt :invert, "Invert fg and bg", :short => 'i', :default => false
+      opt :truecolor, "24-bit (truecolor)", :short => 't', :default => false
       opt :force, "Force color even when stdout is not a tty", :short => 'f', :default => false
       opt :version,  "Print version and exit", :short => 'v'
       opt :help,  "Show this message", :short => 'h'

--- a/lib/lolcat/lol.rb
+++ b/lib/lolcat/lol.rb
@@ -28,6 +28,7 @@ require 'paint'
 
 module Lol
   STRIP_ANSI = Regexp.compile '\e\[[\d;]*[m|K]', nil
+  @paint_detected_mode = Paint.detect_mode
 
   def self.rainbow(freq, i)
      red   = Math.sin(freq*i + 0) * 127 + 128
@@ -59,11 +60,10 @@ module Lol
 
   def self.println_plain(str, defaults={}, opts={})
     opts.merge!(defaults)
+    set_mode(opts[:truecolor])
     str.chomp.chars.each_with_index do |c,i|
       code = rainbow(opts[:freq], opts[:os]+i/opts[:spread])
-      tc   = (opts[:truecolor] ? '=' : '')
-      print Paint[c, *[ (:black if opts[:invert]),
-                        "#{tc}#{code}" ].compact ]
+      print Paint[c, *[ (:black if opts[:invert]), code ].compact ]
     end
   end
 
@@ -75,5 +75,10 @@ module Lol
       println_plain(str, opts)
       sleep 1.0/opts[:speed]
     end
+  end
+
+  def self.set_mode(truecolor)
+    @paint_mode_detected ||= Paint.mode
+    Paint.mode = truecolor ? 0xffffff : @paint_mode_detected
   end
 end

--- a/lib/lolcat/lol.rb
+++ b/lib/lolcat/lol.rb
@@ -60,7 +60,10 @@ module Lol
   def self.println_plain(str, defaults={}, opts={})
     opts.merge!(defaults)
     str.chomp.chars.each_with_index do |c,i|
-      print Paint[c, rainbow(opts[:freq], opts[:os]+i/opts[:spread])]
+      code = rainbow(opts[:freq], opts[:os]+i/opts[:spread])
+      tc   = (opts[:truecolor] ? '=' : '')
+      print Paint[c, *[ (:black if opts[:invert]),
+                        "#{tc}#{code}" ].compact ]
     end
   end
 


### PR DESCRIPTION
Adding maybe like 16 million or so colors just in case you need them.

This branch depends on a patch to `paint` (see janlelis/paint#15) which I dunno if they actually want because I just made the PR right now. I have an alternate branch [here](https://github.com/vaz/lolcat/tree/truecolor-alt) that bypasses `paint` for the truecolor though so don't even worry.

It's pretty much a lot slower printing in truecolor than it already was, but on the other hand just look at it srsly

![lol](https://cl.ly/1d1w3b3S0i0U/download/Image%202016-12-17%20at%201.43.05%20%E5%8D%88%E5%89%8D.png)

(Oh also --invert option yeah?)