### PR TITLE
Fixed bug when arguments include stdin: lolcat file1 - file2 > file3

### DIFF
--- a/lib/lolcat/cat.rb
+++ b/lib/lolcat/cat.rb
@@ -100,15 +100,21 @@ FOOTER
     begin
       files = ARGV.empty? ? [:stdin] : ARGV[0..-1]
       files.each do |file|
-        fd = ARGF if file == '-' or file == :stdin
+        fd = $stdin if file == '-' or file == :stdin
         begin
-          fd = File.open file unless fd == ARGF
+          fd = File.open(file, "r") unless fd == $stdin
 
           if $stdout.tty? or opts[:force]
             Lol.cat fd, opts
           else
-            until fd.eof? do
-              $stdout.write(fd.read(8192))
+            if fd.tty?
+              fd.each do |line|
+                $stdout.write(line)
+              end
+            else
+              until fd.eof? do
+                $stdout.write(fd.read(8192))
+              end
             end
           end
         rescue Errno::ENOENT

--- a/lib/lolcat/version.rb
+++ b/lib/lolcat/version.rb
@@ -1,3 +1,3 @@
 module Lolcat
-  VERSION = "42.24.0"
+  VERSION = "42.24.1"
 end


### PR DESCRIPTION
I ran into a bug using lolcat as a drop-in replacement for the boring /bin/cat.

When multiple files are on a line and - is one of them, the ARGF version duplicates entries. Also, handling tty input as if it were the same as file input leads Ruby (at least on OS/X) to drop the first EOF, so you have to press C-d twice.

Therefore, I've adjusted the file handling to reflect the difference between ttys and files. Thanks for your program to brighten our terminals.