### PR TITLE
Make `nethack | lolcat` work

### DIFF
--- a/lib/lolcat/cat.rb
+++ b/lib/lolcat/cat.rb
@@ -82,7 +82,7 @@ FOOTER
           :spread => 8.0,
           :freq => 0.3
         }
-        Lol.cat buf.read.split(/(?<=\n)/), opts
+        Lol.cat buf, opts
         puts
         buf.close
         exit 1
@@ -112,9 +112,7 @@ FOOTER
                 $stdout.write(line)
               end
             else
-              until fd.eof? do
-                $stdout.write(fd.read(8192))
-              end
+              IO.copy_stream(fd, $stdout)
             end
           end
         rescue Errno::ENOENT


### PR DESCRIPTION
![0](https://user-images.githubusercontent.com/3199732/38172006-c87839c6-35a4-11e8-8fde-28277b7e23b0.png)

For this to work, several things had to change.

First, nethack (like most complex terminal applications) relies on ANSI escape sequences, so we can’t simply strip them. Instead, we let ANSI sequences go through unmodified, and only add color to characters that aren’t part of an ANSI sequence. The `STRIP_ANSI` regex didn’t cover all escape sequences used by NetHack, and so had to be rewritten. This new regex covers all possible escape sequences as specified by [ECMA 048](http://www.ecma-international.org/publications/files/ECMA-ST/Ecma-048.pdf).

Second, nethack doesn’t usually send newlines in its output, causing the `IO#each` method to block forever, waiting for a newline. To work around this, instead of `IO#each`, we use `sysread` and then call `lines` on the resulting buffer. `lolcat -h` was sending an array to `Lol.cat`, which no longer works, and so had to be changed to send a StringIO object instead.

Sadly, using `sysread` causes some regressions: if a read ends in the middle of an escape sequence or UTF-8 character, weird things happen. As a temporary measure, we set a big buffer size (64k), which considerably reduces the frequency at which this problem occurs. A better solution would be to check the buffer for incomplete escape sequences or UTF-8 characters, and read again if there is one.

Third, `nethack | lolcat -a` requires some special handling. lolcat was using `\e[#{str.length}D` to restore the cursor’s position after each “frame”, which of course doesn’t work when `str` contains escape sequences that also affect the cursor’s position. Instead, we use `\e7`/`\e8` to save/restore the cursor’s position, which is much more reliable (as long as the application doesn’t use `\e7` itself). Still, escape sequences that delete characters (`\e[@`, `\e[J`, `\e[K`, `\e[P`, and `\e[X`) can cause a lot of blinking, so we remove them after the first frame.

Those features aren’t specific to nethack, of course. Other complex terminal applications, such as `sl`, `mplayer`, and `htop`, also work correctly when piped into this branch of lolcat.

![0](https://user-images.githubusercontent.com/3199732/38172009-e062f986-35a4-11e8-9aa8-ff82a64dd27d.png)

This PR is another, more polished take on what #52 was trying to do.