### PR TITLE
Snapcraft

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,28 @@
+name: lolcat
+base: core18
+version: git
+summary: Rainbows and unicorns!
+description: |
+  Rainbow-colored output.
+
+grade: stable
+confinement: strict
+
+parts:
+  lolcat:
+    plugin: dump
+    source: .
+    override-build: |
+      gem build lolcat.gemspec
+      gem install lolcat-*.gem -i $SNAPCRAFT_PART_INSTALL
+    build-packages: [gcc, libc6-dev, make, ruby-dev]
+    stage-packages: [ruby]
+
+apps:
+  lolcat:
+    command: lolcat
+    environment:
+      RUBYLIB: $SNAP/usr/lib/ruby/2.5.0:$SNAP/usr/lib/x86_64-linux-gnu/ruby/2.5.0
+      GEM_HOME: $SNAP/gems
+      GEM_PATH: $SNAP
+    command: ruby $SNAP/bin/lolcat

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -20,7 +20,6 @@ parts:
 
 apps:
   lolcat:
-    command: lolcat
     environment:
       RUBYLIB: $SNAP/usr/lib/ruby/2.5.0:$SNAP/usr/lib/x86_64-linux-gnu/ruby/2.5.0
       GEM_HOME: $SNAP/gems


### PR DESCRIPTION
lolcat is awesome and more people should know about it than just the people browsing gems. I work on the Snap Store, which gets [browsed](https://snapcraft.io/store) by millions of Linux users, so I put together a snap of lolcat to get more eyes on it.

To build it, `snap install snapcraft` from Ubuntu, or [install Multipass](https://github.com/CanonicalLtd/multipass/releases) on MacOS then `brew install snapcraft`. Then run `snapcraft` to create the .snap file.

To publish, [create an account](https://snapcraft.io/account), then:
```
snapcraft login
snapcraft register lolcat
snapcraft push --release=stable *.snap
```

From there, you can [add](https://snapcraft.io/lolcat/listing) screenshots and videos so they show up on https://snapcraft.io/lolcat.

Hope this helps :)