### PR TITLE
Provide a hint if target is not a regular file

### DIFF
--- a/lib/lolcat/cat.rb
+++ b/lib/lolcat/cat.rb
@@ -124,6 +124,9 @@ FOOTER
         rescue Errno::EISDIR
           puts "lolcat: #{file}: Is a directory"
           exit 1
+        rescue Errno::ENXIO
+          puts "lolcat: #{file}: Is not a regular file"
+          exit 1
         rescue Errno::EPIPE
           exit 1
         end


### PR DESCRIPTION
Currently it will print traceback if target is a socket file, e.g.

```shell
$ lolcat /tmp/tmux-xxxx/default
Traceback (most recent call last):
	7: from /usr/bin/lolcat:23:in `<main>'
	6: from /usr/bin/lolcat:23:in `load'
	5: from /usr/lib/ruby/gems/2.7.0/gems/lolcat-100.0.0/bin/lolcat:32:in `<top (required)>'
	4: from /usr/lib/ruby/gems/2.7.0/gems/lolcat-100.0.0/lib/lolcat/cat.rb:102:in `cat!'
	3: from /usr/lib/ruby/gems/2.7.0/gems/lolcat-100.0.0/lib/lolcat/cat.rb:102:in `each'
	2: from /usr/lib/ruby/gems/2.7.0/gems/lolcat-100.0.0/lib/lolcat/cat.rb:105:in `block in cat!'
	1: from /usr/lib/ruby/gems/2.7.0/gems/lolcat-100.0.0/lib/lolcat/cat.rb:105:in `open'
/usr/lib/ruby/gems/2.7.0/gems/lolcat-100.0.0/lib/lolcat/cat.rb:105:in `initialize': No such device or address @ rb_sysopen - /tmp/tmux-xxxx/default (Errno::ENXIO)
```
