### PR TITLE
Allow using optimist 3.1

### DIFF
--- a/lolcat.gemspec
+++ b/lolcat.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency "rake"
   s.add_dependency "paint", "~> 2.1"
-  s.add_dependency "optimist", "~> 3.0.0"
+  s.add_dependency "optimist", "~> 3.0"
   s.add_dependency "manpages", "~> 0.6.1"
 
   s.files         = `git ls-files`.split("\n")


### PR DESCRIPTION
Simple relaxing of version constraint, since it seems to work